### PR TITLE
chore: clean up old acronyms

### DIFF
--- a/pkg/api/proto/cluster_orchestrator_southbound.pb.go
+++ b/pkg/api/proto/cluster_orchestrator_southbound.pb.go
@@ -268,7 +268,7 @@ func (x *RegisterClusterRequest) GetNodeGuid() string {
 	return ""
 }
 
-// RegisterClusterResponse contains shell script to be executed by Cluster Agent to install LPKE
+// RegisterClusterResponse contains shell script to be executed by Cluster Agent to install cluster
 type RegisterClusterResponse struct {
 	state         protoimpl.MessageState         `protogen:"open.v1"`
 	InstallCmd    *ShellScriptCommand            `protobuf:"bytes,1,opt,name=install_cmd,json=installCmd,proto3" json:"install_cmd,omitempty"`
@@ -333,7 +333,8 @@ func (x *RegisterClusterResponse) GetRes() RegisterClusterResponse_Result {
 // command is to be executed in shell, like this `sh -c command`
 type ShellScriptCommand struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// example: "/usr/local/bin/rancher-system-agent-uninstall.sh; /usr/local/bin/rke2-uninstall.sh"
+	// example1: "curl -fL https://DOMAIN.NAME/system-agent-install.sh | sudo  sh -s - --server https://DOMAIN.NAME --label 'cattle.io/os=linux' --token 86f9cqfnvvlmwmvvmsptmr5wqj9d6bqpxkmxbvjw2txklhbglcdtff --ca-checksum b50da8bfa2cbcc13e209b9ffbab4b39c699e0aa2b3fe50f44ec4477c54725ea3 --etcd --controlplane --worker"
+	// example2: "/usr/local/bin/rancher-system-agent-uninstall.sh; /usr/local/bin/rke2-uninstall.sh"
 	Command       string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/api/proto/cluster_orchestrator_southbound.proto
+++ b/pkg/api/proto/cluster_orchestrator_southbound.proto
@@ -6,13 +6,13 @@ import "validate/validate.proto";
 option go_package = ".;cluster_orchestrator_southbound";
 
 service ClusterOrchestratorSouthbound {
-  // RegisterCluster is called from Edge Node to receive LPKE installation script
+  // RegisterCluster is called from Edge Node to receive cluster installation script
   rpc RegisterCluster(RegisterClusterRequest) returns (RegisterClusterResponse) {}
 
   // UpdateClusterStatus is called from Edge Cluster to set the status cluster deployment
   rpc UpdateClusterStatus(UpdateClusterStatusRequest) returns (UpdateClusterStatusResponse) {}
 
-  // GetClusterNumByTemplateIdentifier is called from CTM service
+  // GetClusterNumByTemplateIdentifier is called from Cluster Manager service
   rpc GetClusterNumByTemplateIdentifier(GetClusterNumByTemplateIdentifierRequest) returns (GetClusterNumByTemplateIdentifierResponse) {}
 }
 
@@ -21,7 +21,7 @@ message RegisterClusterRequest {
   string node_guid = 1 [(validate.rules).string = { pattern: "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$"}];
 }
 
-// RegisterClusterResponse contains shell script to be executed by Cluster Agent to install LPKE
+// RegisterClusterResponse contains shell script to be executed by Cluster Agent to install cluster
 message RegisterClusterResponse {
   ShellScriptCommand install_cmd = 1;
   ShellScriptCommand uninstall_cmd = 2;

--- a/pkg/api/proto/cluster_orchestrator_southbound_grpc.pb.go
+++ b/pkg/api/proto/cluster_orchestrator_southbound_grpc.pb.go
@@ -28,11 +28,11 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ClusterOrchestratorSouthboundClient interface {
-	// RegisterCluster is called from Edge Node to receive LPKE installation script
+	// RegisterCluster is called from Edge Node to receive cluster installation script
 	RegisterCluster(ctx context.Context, in *RegisterClusterRequest, opts ...grpc.CallOption) (*RegisterClusterResponse, error)
 	// UpdateClusterStatus is called from Edge Cluster to set the status cluster deployment
 	UpdateClusterStatus(ctx context.Context, in *UpdateClusterStatusRequest, opts ...grpc.CallOption) (*UpdateClusterStatusResponse, error)
-	// GetClusterNumByTemplateIdentifier is called from CTM service
+	// GetClusterNumByTemplateIdentifier is called from Cluster Manager service
 	GetClusterNumByTemplateIdentifier(ctx context.Context, in *GetClusterNumByTemplateIdentifierRequest, opts ...grpc.CallOption) (*GetClusterNumByTemplateIdentifierResponse, error)
 }
 
@@ -78,11 +78,11 @@ func (c *clusterOrchestratorSouthboundClient) GetClusterNumByTemplateIdentifier(
 // All implementations must embed UnimplementedClusterOrchestratorSouthboundServer
 // for forward compatibility.
 type ClusterOrchestratorSouthboundServer interface {
-	// RegisterCluster is called from Edge Node to receive LPKE installation script
+	// RegisterCluster is called from Edge Node to receive cluster installation script
 	RegisterCluster(context.Context, *RegisterClusterRequest) (*RegisterClusterResponse, error)
 	// UpdateClusterStatus is called from Edge Cluster to set the status cluster deployment
 	UpdateClusterStatus(context.Context, *UpdateClusterStatusRequest) (*UpdateClusterStatusResponse, error)
-	// GetClusterNumByTemplateIdentifier is called from CTM service
+	// GetClusterNumByTemplateIdentifier is called from Cluster Manager service
 	GetClusterNumByTemplateIdentifier(context.Context, *GetClusterNumByTemplateIdentifierRequest) (*GetClusterNumByTemplateIdentifierResponse, error)
 	mustEmbedUnimplementedClusterOrchestratorSouthboundServer()
 }

--- a/pkg/mocks/mock-secret-client/mock_secret_client.go
+++ b/pkg/mocks/mock-secret-client/mock_secret_client.go
@@ -28,25 +28,7 @@ func (MockSecretClient) Patch(secretPath string, secretkvMap map[string]interfac
 
 func (MockSecretClient) Get(secretPath string) (*api.KVSecret, error) {
 	switch secretPath {
-	case "co-ecm-db-pwd":
-		return &api.KVSecret{
-			Data: map[string]interface{}{
-				"db-pwd": "password",
-			},
-			VersionMetadata: nil,
-			CustomMetadata:  nil,
-			Raw:             nil,
-		}, nil
-	case "co-ctm-db-pwd":
-		return &api.KVSecret{
-			Data: map[string]interface{}{
-				"db-pwd": "password",
-			},
-			VersionMetadata: nil,
-			CustomMetadata:  nil,
-			Raw:             nil,
-		}, nil
-	case "amrregistrycaasintelcom":
+	case "co-cm-db-pwd":
 		return &api.KVSecret{
 			Data: map[string]interface{}{
 				"db-pwd": "password",


### PR DESCRIPTION
### Description

Remove old acronyms from comments and regenerate proto file with `make proto-generate`

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

CI only

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code