### PR TITLE
fix: fuzz env not init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated 
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: fuzz
-fuzz: ## Run Fuzz tests
-	hack/fuzz_all.sh ${FUZZTIME}
+fuzz: envtest ## Run Fuzz tests
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" hack/fuzz_all.sh ${FUZZTIME}
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter


### PR DESCRIPTION
### Description

`make fuzz` failing as kubebuilder assets were not available.

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Locally running `make fuzz`

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code