### PR TITLE
Update post-merge.yml run security scans in post merge

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -34,6 +34,7 @@ jobs:
       run_docker_push: true
       run_helm_build: true
       run_helm_push: true
+      run_security_scans: true
       trivy_image_skip: |
         ghcr.io/github/github-mcp-server:latest,
         ghcr.io/github/gh-aw-mcpg:latest,


### PR DESCRIPTION
This pull request introduces an update to the post-merge GitHub Actions workflow to enhance security practices.

**Security and CI/CD Improvements:**

* [`.github/workflows/post-merge.yml`](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aR37): Enabled the `run_security_scans` step in the workflow, ensuring that security scans are now executed automatically after merges.