### PR TITLE
Update dependabot.yml change to weekly updates for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request makes a small configuration change to the Dependabot schedule. The update changes the frequency of GitHub Actions dependency checks from daily to weekly.