### PR TITLE
Update post-merge.yml revert https://github.com/open-edge-platform/cluster-api-provider-intel/pull/482

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -34,7 +34,6 @@ jobs:
       run_docker_push: true
       run_helm_build: true
       run_helm_push: true
-      run_security_scans: true
       trivy_image_skip: |
         ghcr.io/github/github-mcp-server:latest,
         ghcr.io/github/gh-aw-mcpg:latest,


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/post-merge.yml` workflow configuration. The change disables the `run_security_scans` step by removing its configuration line. No other changes are included.

([.github/workflows/post-merge.ymlL37](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL37))