### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch: 
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that the workflow defined in `.github/workflows/post-merge.yml` will now also run when any tag is pushed, in addition to the existing triggers for the `main` and `release-*` branches.